### PR TITLE
Reverting texlive version from v23.08 to v22.08

### DIFF
--- a/eu.ad5001.LogarithmPlotter.json
+++ b/eu.ad5001.LogarithmPlotter.json
@@ -15,7 +15,7 @@
     "add-extensions": {
         "org.freedesktop.Sdk.Extension.texlive": {
             "directory": "texlive",
-            "version": "23.08"
+            "version": "22.08"
         }
     },
     "command": "logarithmplotter",


### PR DESCRIPTION
Version 23.08 has higher GLibc requirements that make it incompatible with some LTS distros.